### PR TITLE
change favicon color in accordance with device theme

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,8 @@
 
     {% seo %}
 
-    <link rel="shortcut icon" type="image/x-icon" href="{{ "/assets/favicon.ico" | relative_url }}">
+    <link rel="icon" type="image/x-icon" href="{{ "/assets/favicon.ico" | relative_url }}">
+    <link rel="icon" type="image/svg+xml" href="{{ "/assets/favicon.svg" | relative_url }}">
 
     <!-- Google Fonts -->
     <link rel="stylesheet"

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,16 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css">
+        .fg {
+            fill: #272727;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            .fg {
+                fill: white;
+            }
+        }
+    </style>
+    <path class="fg" d="M0 1L1 1L1 2L15 2L15 1L16 1L16 0L0 0L0 1Z" fill="#272727" fill-rule="nonzero" opacity="1" stroke="none"/>
+    <path class="fg" d="M4 3L4 14L1 14L1 15L0 15L0 16L16 16L16 15L15 15L15 14L6 14L6 11L11 11L11 10L12 10L12 4L11 4L11 3L4 3ZM6 5L10 5L10 9L6 9L6 5Z"
+          fill="#272727" fill-rule="nonzero" opacity="1" stroke="none"/>
+</svg>


### PR DESCRIPTION
I've converted the favicon to svg and added some CSS so that it looks better in combination with darker browser color themes.

Before:
<img width="159" alt="image" src="https://user-images.githubusercontent.com/13941584/192123895-18c2ba3e-f081-44d2-8a50-4ba06afa8dcb.png">

After:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/13941584/192123905-3d2b0f8f-f55d-4ad3-9e8c-26512a45a3fa.png">
